### PR TITLE
if initial parse labels non-gaps as GAP, change to N-Head by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -678,6 +678,11 @@ def edit():
 		treestr = writediscbrackettree(tree, senttok, pretty=True).rstrip()
 		rows = max(5, treestr.count('\n') + 1)
 	else:
+		# if initial parse labels non-gaps as GAP, change to N-Head by default
+		for subt in tree.subtrees(lambda t: t.height() == 2):
+			i = subt[0]
+			if subt.label.startswith('GAP') and senttok[i] != '_.':
+				subt.label = 'N-Head'
 		# writetree requires a string to be passed as its third argument; '1' is a dummy value 
 		block = writetree(tree, senttok, '1', 'export', comment='')  #comment='%s %r' % (username, actions))
 		block = io.StringIO(block)


### PR DESCRIPTION
Sometimes, activedop's 'best' initial parse assigns a `GAP*` label to a non-gap terminal node. A user may want to select this parse and edit in edit mode; the problem is that when the user opens the tree in edit mode, activedop converts an export-format tree into CGELBank format tree with `load_as_cgel`, which asserts that for every `GAP*`-labeled node,  the node text = gap token `_.`

This change circumvents the issue by converting the label of such nodes from `GAP*` to `N-Head`. 