### PR TITLE
bugfixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,11 +128,14 @@ PUNCTRE = re.compile(r'^(\W+)$')
 PUNCTRE_LABEL = re.compile(r'.*-p$')
 INITIAL_PUNCT_LABELS = {'LRB-p', '[-p', '{-p'}
 
-def is_possible_punct_sequence(token):
-	return re.match(PUNCTRE, token) or token in [e['ptree_token'] for e in PUNCT_ESCAPING]
+def is_punct_postag(tag):
+	return tag in PUNCT_TAGS.values() or tag == SYMBOL_TAG
 
 def is_punct_label(label):
 	return re.match(PUNCTRE_LABEL, label) or label in [e['ptree_label'] for e in PUNCT_ESCAPING]
+
+def is_possible_punct_token(token):
+	return re.match(PUNCTRE, token) or token in PUNCT_TAGS.keys() or token in [i['ptree_token'] for i in PUNCT_ESCAPING]
 
 def senttok_escape(senttok):
 	"""Replace special characters in a tokenized sentence.
@@ -875,10 +878,10 @@ def tree_process(tree : ParentedTree, senttok: List[str]) -> tuple[ParentedTree,
 		# condition 2: label is punctuation sequence (which may or may not be the correct one for the token) + "-p"
 		# condition 3: token is unabiguously punctuation
 		# -> assign the appropriate punctuation label (either from PUNCT_TAGS or the default SYMBOL_TAG)
-		if is_possible_punct_sequence(subt.label) or is_punct_label(subt.label) or (is_possible_punct_sequence(senttok[i]) and senttok[i] not in AMBIG_SYM):
+		if is_punct_postag(subt.label) or is_punct_label(subt.label) or (is_possible_punct_token(senttok[i]) and senttok[i] not in AMBIG_SYM):
 			subt.label = PUNCT_TAGS.get(senttok[i], SYMBOL_TAG) + "-p"
 			# if initial parse labels non-punctuation as punctuation, change to N-Head
-		if (not is_possible_punct_sequence(senttok[i])) and (is_punct_label(subt.label)):
+		if (not is_possible_punct_token(senttok[i])) and (is_punct_label(subt.label)):
 			subt.label = 'N-Head'
 		ptree_terminals.append(subt)
 
@@ -970,7 +973,7 @@ def add_editable_attribute(htmltree :str) -> str:
 		# extract the preterminal's function and pos tag from the span's `data-s` attribute:
 		label = re.search(r'data-s="([^"]*)"', preterminal).group(1).split(' ')[0]
 		m = LABELRE.match(label)
-		if m.group(2) == "-p" or is_possible_punct_sequence(m.group(1)):
+		if m.group(2) == "-p" or is_punct_postag(m.group(1)):
 			htmltree = htmltree.replace(preterminal, preterminal.replace('class=p', 'class=p editable="false"'))
 		else:
 			htmltree = htmltree.replace(preterminal, preterminal.replace('class=p', 'class=p editable="true"'))

--- a/app.py
+++ b/app.py
@@ -1001,6 +1001,7 @@ def redraw():
 			msg += validate_cgel(cgel_tree)
 	except ValueError as err:
 		return str(err)
+	treestr = cgel_tree
 	link = ('<a href="/annotate/accept?%s">accept this tree</a>'
 		% urlencode(dict(sentno=sentno, tree=treestr)))
 	oldtree = request.args.get('oldtree', '')

--- a/app.py
+++ b/app.py
@@ -125,14 +125,13 @@ AMBIG_SYM = {
 
 LABELRE = re.compile(r'^([^-/\s]+)(-[^/\s]+)?(/\S+)?$')
 PUNCTRE = re.compile(r'^(\W+)$')
-PUNCTRE_LABEL = re.compile(r'.*-p$')
 INITIAL_PUNCT_LABELS = {'LRB-p', '[-p', '{-p'}
 
 def is_punct_postag(tag):
 	return tag in PUNCT_TAGS.values() or tag == SYMBOL_TAG
 
 def is_punct_label(label):
-	return re.match(PUNCTRE_LABEL, label) or label in [e['ptree_label'] for e in PUNCT_ESCAPING]
+	return label.endswith('-p')
 
 def is_possible_punct_token(token):
 	return re.match(PUNCTRE, token) or token in PUNCT_TAGS or token in [i['ptree_token'] for i in PUNCT_ESCAPING]

--- a/app.py
+++ b/app.py
@@ -873,8 +873,8 @@ def tree_process(tree : ParentedTree, senttok: List[str]) -> tuple[ParentedTree,
 		# if initial parse labels non-gaps as GAP, change to N-Head by default
 		if subt.label.startswith('GAP') and senttok[i] != '_.':
 			subt.label = 'N-Head'
-		# condition 1: label is a punctuation sequence w/o -p. [e.g, the label in node `(, ,)`]. Can occur in `annotate` when tree_process() receives an initial dopparsed tree, and in `edit` when tree_process() receives a ParentedTree-format PTB-converted ctree. 
-		# condition 2: label is punctuation sequence (which may or may not be the correct one for the token) + "-p"
+		# condition 1: label consists of a recognized punctuation pos tag, without a function tag [e.g, the label in node `(, ,)`]. Can occur in `annotate` when tree_process() receives an initial dopparsed tree, and in `edit` when tree_process() receives a ParentedTree-format PTB-converted ctree. 
+		# condition 2: label contains a "p" function tag
 		# condition 3: token is unabiguously punctuation
 		# -> assign the appropriate punctuation label (either from PUNCT_TAGS or the default SYMBOL_TAG)
 		if is_punct_postag(subt.label) or is_punct_label(subt.label) or (is_possible_punct_token(senttok[i]) and senttok[i] not in AMBIG_SYM):

--- a/app.py
+++ b/app.py
@@ -135,7 +135,7 @@ def is_punct_label(label):
 	return re.match(PUNCTRE_LABEL, label) or label in [e['ptree_label'] for e in PUNCT_ESCAPING]
 
 def is_possible_punct_token(token):
-	return re.match(PUNCTRE, token) or token in PUNCT_TAGS.keys() or token in [i['ptree_token'] for i in PUNCT_ESCAPING]
+	return re.match(PUNCTRE, token) or token in PUNCT_TAGS or token in [i['ptree_token'] for i in PUNCT_ESCAPING]
 
 def senttok_escape(senttok):
 	"""Replace special characters in a tokenized sentence.

--- a/settings.cfg
+++ b/settings.cfg
@@ -1,7 +1,7 @@
 SECRET_KEY=b';boc.xbanuh;qdaoeiq'
 DEBUG = False
 GRAMMAR = 'cgelbank2-punct/'
-SENTENCES = 'newsentsExample2.csv'
+SENTENCES = 'newsentsExample.csv'
 LIMIT = 70
 ANNOTATIONHELP = None
 ACCOUNTS = {


### PR DESCRIPTION
1. https://github.com/nschneid/activedop/pull/59/commits/03b750fceb6eafba8c70c69334fd94c22953ca76 addresses https://github.com/nschneid/activedop/issues/58 -- settings.cfg referenced a sentences file that wasn't in the repo.
2. https://github.com/nschneid/activedop/pull/59/commits/0be4f5370af569ed89907f2fd45b12c77eab927f addresses https://github.com/nschneid/activedop/issues/60 -- `tree_process()` was improperly handling detection of punctuation preterminals. This commit separates out `is_possible_punct_sequence()` into two functions, `is_punct_postag()` and `is_possible_punct_token()` -- the former is called within `tree_process()` to ensure that a preterminal consisting of *just* a punctuation POS tag receives the appropriate `-p` function label. Subsequently within `tree_process`, a punctuation label is changed to `N-Head` by default if the corresponding terminal node is not a recognized punctuation token.
3. I noticed an issue that prevented users from accepting trees w/o first performing edits. Addressed by https://github.com/nschneid/activedop/pull/59/commits/f9955505d57106cb2fd651938e41c6d0af095cd5.