### PR TITLE
In ptb2ptree, escape punct preterminals that don't have an idiosyncratic tag 

### DIFF
--- a/app.py
+++ b/app.py
@@ -1770,6 +1770,8 @@ def ptb2ptree(inputfile, outputfile):
 			for subt in ptree.subtrees(lambda t: t.height() == 2):
 				if subt.label in PUNCT_TAGS:
 					subt.label = PUNCT_TAGS[subt.label]
+				elif is_possible_punct_token(subt.label):
+					subt.label = SYMBOL_TAG
 			ptree, _ = tree_process(ptree, senttok)
 			# remove -p function label for training the parser
 			for subt in ptree.subtrees(lambda t: t.height() == 2):


### PR DESCRIPTION
Ensures that, e.g., we convert`(!? !?)` in a ptb tree [the output of cgel2ptb.py] to `(* !?)` in the corresponding ptree [the output of the `ptb2ptree` endpoint in app.py, which we use to create trees that train the discodop parser]. 