### PR TITLE
strip extra whitespace from retokenized sentences

### DIFF
--- a/templates/annotate.html
+++ b/templates/annotate.html
@@ -60,6 +60,9 @@
 	
 	function reTokenize(sentno) {
 		var newtext = document.getElementById('editInput').value;
+		newtext = newtext.trim();
+		newtext = newtext.replace(/\s+/g, ' ');
+		document.getElementById('editInput').value = newtext;
 		var sentno = document.getElementById('sentno').value;
 		document.getElementById('editableSent').innerText = newtext;
 		document.getElementById('editableSent').style.display = "inline";


### PR DESCRIPTION
When retokenizing from the web interface, it's possible for a user to introduce extraneous leading, trailing, or multiple whitespaces into the sentence (e.g., `   This is    a test sentence   `). This can lead to problems down the road, because that string replaces the old entry for the sentence in `SENTENCES`. 

This fix automatically corrects extra whitespace after the user hits "Re-tokenize". In the above example, the resulting entry for `SENTENCES` is `This is a test sentence`. This change also cleans up the text in the input field. 