### PR TITLE
fix #75

### DIFF
--- a/app.py
+++ b/app.py
@@ -789,7 +789,7 @@ def edit():
 				if sentno < len(SENTENCES) else '/annotate/annotate/1',
 			unextlink=('/annotate/annotate/%d' % firstunannotated(username))
 				if sentno < len(SENTENCES) else '#',
-			treestr=treestr, senttok=sent, id=id,
+			treestr=treestr, senttok=' '.join(senttok), id=id,
 			sentno=sentno, lineno=lineno + 1, totalsents=len(SENTENCES),
 			numannotated=numannotated(username),
 			poslabels=sorted(t for t in workerattr('poslabels') if ('@' not in t) and (t not in PUNCT_TAGS.values()) and (t != SYMBOL_TAG)),


### PR DESCRIPTION
Displayed sentence is a concatenation of tokens from the saved tree (rather than the original sentence from `initpriorities`). 