### PR TITLE
HTTPS submodule paths in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/nert-nlp/cgel
 [submodule "roaringbitmap"]
 	path = roaringbitmap
-	url = git@github.com:andreasvc/roaringbitmap.git
+	url = https://github.com/andreasvc/roaringbitmap
 [submodule "disco-dop"]
 	path = disco-dop
-	url = git@github.com:andreasvc/disco-dop.git
+	url = https://github.com/andreasvc/disco-dop


### PR DESCRIPTION
In `.gitmodules`, specifying HTTPS submodule paths allows users to clone submodules without an SSH connection