### PR TITLE
#90 source argument for ActivedopTree object initialization

### DIFF
--- a/activedoptree.py
+++ b/activedoptree.py
@@ -1,10 +1,9 @@
 from collections import defaultdict
 import copy
 import io
-from typing import List
 import traceback
 from discodop.tree import (Tree, ParentedTree, writediscbrackettree,
-							DrawTree, brackettree, discbrackettree)
+							DrawTree, brackettree)
 from discodop.treebank import writetree
 import re
 import sys
@@ -50,7 +49,7 @@ def cgel_to_ptree_rec(cgel_tree, head: int, depth: int, punct: bool=True):
 	if punct:
 		for p in node.prepunct:
 			result.append(ParentedTree(p+"-p", []))
-	tag = node.constituent.replace("_","")
+	tag = node.constituent
 	if node.label != '' and node.label is not None:
 		tag += '.' + node.label
 	if node.deprel != '' and node.deprel is not None:
@@ -85,30 +84,43 @@ def cgel_to_ptree(cgel_tree, punct: bool=True, gap_token_symbol: str='_.', compl
 	return ptree, senttok
 
 class ActivedopTree:
-	"""Wrapper for a ParentedTree object with additional methods for activedop."""
-	def __init__(self, ptree: ParentedTree, senttok: List[str], cgel_terminals = None):
+	"""Wrapper for a tree object with additional methods for activedop."""
+	def __init__(self, source = 'ptree', **kwargs):
 		"""
-		ptree: ParentedTree object with terminals that are numeric indices.
-		senttok: list of tokens corresponding to the terminals of ptree.
-		cgel_terminals: a list of CGELTree terminals (optional, to replace terminals of CGELTree in initialization).
+		source ['ptree', 'cgel']: the source of the tree (`ParentedTree` or CGEL `Tree` object)
 		"""
 		from flask import current_app
 		self.app = current_app
-		self.ptree = ptree
-		self.senttok = senttok
+		if source == 'ptree':
+			self.ptree = kwargs.get('ptree')
+			self.senttok = kwargs.get('senttok')
+			# convert ptree to a CGELTree object
+			self.cgel_tree = self._ptree_to_cgel()
+			# update cgel_tree with a set of terminals if provided
+			cgel_tree_terminals = kwargs.get('cgel_tree_terminals', None)
+			if cgel_tree_terminals is not None:
+				self.cgel_tree.update_terminals(cgel_tree_terminals, gaps=True, restore_old_cat=True, restore_old_func=True, restore_old_label=True)
+		elif source == 'cgel':
+			self.cgel_tree = kwargs.get('cgel_tree')
+		# if original source is ptree, back-converting from cgel_tree canonicalizes punctuation positions in the ptree
+		self.ptree, self.senttok = cgel_to_ptree(self.cgel_tree)
 		# standardize ptree with correct labels for punctuation and gaps
 		self.ptree = self._apply_standard_labels()
-		ptree_terminals_with_labels = copy.deepcopy([subt for subt in self.ptree.subtrees(lambda t: t.height() == 2)])
-		# convert ptree to a CGELTree object
-		self.cgel_tree = self._ptree_to_cgel()
-		# back-convert the CGELTree object to a ParentedTree object to canonicalize punctuation positions
-		self.ptree, self.senttok = cgel_to_ptree(self.cgel_tree)
 		# update canonicalized ptree with standardized labels
+		ptree_terminals_with_labels = copy.deepcopy([subt for subt in self.ptree.subtrees(lambda t: t.height() == 2)])
 		for i, subt in enumerate(self.ptree.subtrees(lambda t: t.height() == 2)):
-			subt.label = ptree_terminals_with_labels[i].label
-		# update cgel_tree with a set of terminals if provided
-		if cgel_terminals is not None:
-			self.cgel_tree.update_terminals(cgel_terminals, gaps=True, restore_old_cat=True, restore_old_func=True, restore_old_label=True)
+				subt.label = ptree_terminals_with_labels[i].label
+		# remove underscores from ptree category labels and hyphens from ptree function labels
+		for subt in self.ptree.subtrees(lambda t: t.height() > 1):
+			cat = None
+			func = None
+			pos = None
+			label = LABELRE.match(subt.label)
+			if label.group(1) is not None:
+				cat = label.group(1).replace('_', '')
+			if label.group(2) is not None:
+				func = label.group(2).replace('-', '')
+			subt.label = cat + (('-' + func) if func is not None else '') + (('/' + pos) if pos is not None else '')
 
 	def brackettreestr(self, pretty = False):
 		"""returns a string representation of ptree in bracket notation, with labels consisting of a POS tag and a function tag separated by a hyphen."""
@@ -349,6 +361,8 @@ class ActivedopTree:
 			msg += '\n(CGEL VALIDATOR IS OFF)\n'
 		else:
 			errS = errS.getvalue()
+			if 'Invalid category name' in errS:
+				errS += 'Missing underscores in category names will be added automatically upon graphical tree edit.'
 			if errS:
 				msg += '\nCGEL VALIDATOR\n==============\n' + errS
 			else:
@@ -366,24 +380,25 @@ class ActivedopTree:
 		# check tree structure
 		coindexed = defaultdict(set)	# {coindexationvar -> {labels}}
 		for node in tree.subtrees():
-			if node is not tree.root and node.label==tree.root.label:
-				raise ValueError(('ERROR: non-root node cannot have same label as root: '+node.label))
-			m = LABELRE.match(node.label)
+			# create copy of node to validate POS and function tags
+			node_to_validate = copy.deepcopy(node)
+			# strip -p from label if present
+			if node_to_validate.label.endswith('-p'):
+				node_to_validate.label = node_to_validate.label[:-2]
+			if node is not tree.root and node_to_validate.label==tree.root.label:
+				raise ValueError(('ERROR: non-root node cannot have same label as root: '+node_to_validate.label))
+			m = LABELRE.match(node_to_validate.label)
 			if m is None:
 				raise ValueError('malformed label: %r\n'
 						'expected: cat-func/morph or cat-func; e.g. NN-SB/Nom'
-						% node.label)
+						% node_to_validate.label)
 			else:
-				mCoidx = COIDXRE.search(node.label)
+				mCoidx = COIDXRE.search(node_to_validate.label)
 				if mCoidx:
-					coindexed[mCoidx.group(1)].add(node.label)
-			if len(node) == 0:
+					coindexed[mCoidx.group(1)].add(node_to_validate.label)
+			if len(node_to_validate) == 0:
 				raise ValueError(('ERROR: a constituent should have '
-						'one or more children:\n%s' % node))
-			# create copy of node to validate POS and function tags (stripping -p from label if present)
-			node_to_validate = copy.deepcopy(node)
-			if node_to_validate.label.endswith('-p'):
-				node_to_validate.label = node.label[:-2]
+						'one or more children:\n%s' % node_to_validate))
 			# a POS tag
 			elif isinstance(node_to_validate[0], int):
 				if not self._isValidPOS(m.group(1)):
@@ -445,9 +460,7 @@ class ActivedopTree:
 			if add_root:
 				tree = "(ROOT" + tree + ")"
 			ptree, senttok = brackettree(tree)
-			return cls(ptree, senttok)
+			return cls(source = 'ptree', ptree = ptree, senttok = senttok)
 		else:
 			cgel_tree = cgel.parse(tree)[0]
-			cgel_terminals = cgel_tree.terminals(gaps=True)
-			ptree, senttok = cgel_to_ptree(cgel_tree)
-			return cls(ptree, senttok, cgel_terminals)
+			return cls(source = 'cgel', cgel_tree = cgel_tree)

--- a/app.py
+++ b/app.py
@@ -551,7 +551,7 @@ def parse():
 		result = ''
 		dectree, maxdepth, _ = decisiontree(parsetrees, senttok, urlprm)
 		prob, ptree, _treestr, _fragments = parsetrees[0]
-		treeobj = ActivedopTree(ptree, senttok)
+		treeobj = ActivedopTree(source ='ptree', ptree = ptree, senttok = senttok)
 		nbest = Markup('%s\nbest tree: %s' % (
 				dectree,
 				('%(n)d. [%(prob)s] '
@@ -605,8 +605,8 @@ def filterparsetrees():
 			worker.getparses,
 			sent, require, block).result()
 	senttok, parsetrees, _messages, _elapsed = resp
-	parsetrees_ = [(n, prob, ActivedopTree(tree, senttok), treestr, frags)
-			for n, (prob, tree, treestr, frags) in enumerate(parsetrees)
+	parsetrees_ = [(n, prob, ActivedopTree(source = 'ptree', ptree = ptree, senttok = senttok), treestr, frags)
+			for n, (prob, ptree, treestr, frags) in enumerate(parsetrees)
 			if treestr is None or testconstraints(treestr, frequire, fblock)]
 	if len(parsetrees_) == 0:
 		return ('No parse trees after filtering; try pressing Re-parse, '
@@ -684,8 +684,8 @@ def edit():
 				worker.getparses,
 				sent, require, block).result()
 		senttok, parsetrees, _messages, _elapsed = resp
-		tree = parsetrees[n - 1][1]
-		treeobj = ActivedopTree(tree, senttok)
+		ptree = parsetrees[n - 1][1]
+		treeobj = ActivedopTree(source = 'ptree', ptree = ptree, senttok = senttok)
 	else:
 		return 'ERROR: pass n or tree argument.'
 	rows = max(5, treeobj.treestr().count('\n') + 1)
@@ -742,7 +742,8 @@ def graphical_operation_preamble(treestr):
 
 def graphical_operation_postamble(dt, senttok, cgel_tree_terminals, sentno):
 	ptree = ParentedTree.convert(canonicalize(dt.nodes[0]))
-	treeobj = ActivedopTree(ptree, senttok, cgel_tree_terminals)
+	treeobj = ActivedopTree(source = 'ptree', ptree = ptree, senttok = senttok, 
+						 cgel_tree_terminals = cgel_tree_terminals)
 	msg = treeobj.validate()
 	link = ('<a href="/annotate/accept?%s">accept this tree</a>'
 		% urlencode(dict(sentno=sentno, tree=treeobj.treestr())))	
@@ -1025,7 +1026,8 @@ def replacesubtree():
 		a[0] = subseq[n]
 	dt.nodes[nodeid][:] = newsubtree[:]
 	ptree = ParentedTree.convert(canonicalize(dt.nodes[0]))
-	treeobj = ActivedopTree(ptree, treeobj.senttok, cgel_tree_terminals)
+	treeobj = ActivedopTree(source = 'ptree', ptree = ptree, senttok = treeobj.senttok, 
+						 cgel_tree_terminals = cgel_tree_terminals)
 	session['actions'][REPARSE] += 1
 	session.modified = True
 	link = ('<a href="/annotate/accept?%s">accept this tree</a>'
@@ -1077,8 +1079,8 @@ def accept():
 				worker.getparses,
 				sent, require, block).result()
 		senttok, parsetrees, _messages, _elapsed = resp
-		tree = parsetrees[n - 1][1]
-		treeobj = ActivedopTree(tree, senttok)
+		ptree = parsetrees[n - 1][1]
+		treeobj = ActivedopTree(souce = 'ptree', ptree = ptree, senttok = senttok)
 		tree_to_train, cgel_tree = treeobj.ptree, treeobj.cgel_tree
 		if False:
 			# strip function tags
@@ -1308,7 +1310,7 @@ def cgel2export(inputfile, outputfile):
 		for tree in cgel.trees(f):
 			ptree, senttok = cgel_to_ptree(tree)
 			print(tree.metadata)
-			treeobj = ActivedopTree(ptree, senttok)
+			treeobj = ActivedopTree(source = 'ptree', ptree = ptree, senttok = senttok)
 			# remove -p function label for training the parser
 			for subt in treeobj.ptree.subtrees(lambda t: t.height() == 2):
 				if subt.label.endswith("-p"):


### PR DESCRIPTION
Following discussion in https://github.com/nschneid/activedop/issues/90: 

- Introduces an argument `source` in the initialization of ActivedopTree arguments. If `source = ptree`, then the `ptree`/`senttok` object attributes are valued from kwargs (and `cgel_tree` attribute is valued from ptree-to-CGELTree conversion). If `source = cgel`, then the `cgel_tree` object attribute is valued from a kwarg (and `ptree`/`senttok` attributes are valued from CGELTree-to-ptree conversion);
- Updates the CGEL submodule with new, extensional method for validating CGELTree category labels; 
- Adds a footer to validation error messages that contain `Invalid category name` error: `Missing underscores in category names will be added automatically upon graphical tree edit.` 

This change simplifies the construction of ActivedopTree objects, in that it removes a superfluous format conversion (CGEL -> ptree -> CGEL) when ActivedopTree objects are constructed from CGEL trees. 

It also enhances the user editing experience: if the user misses an underscore when manually editing CGEL tree category labels (e.g., `Npro`), the user is thrown an error. (But note: a subsequent graphical tree edit automatically corrects this kind of error). 