### PR TITLE
handle text window edits that result in deficient tree structures

### DIFF
--- a/activedoptree.py
+++ b/activedoptree.py
@@ -450,5 +450,8 @@ class ActivedopTree:
 			ptree, senttok = brackettree(tree)
 			return cls(ptree = ptree, senttok = senttok)
 		else:
-			cgel_tree = cgel.parse(tree)[0]
+			try:
+				cgel_tree = cgel.parse(tree)[0]
+			except Exception:
+				raise ValueError(f'Format error in CGEL input. Check for matching parentheses, quotes, etc.')
 			return cls(cgel_tree = cgel_tree)

--- a/app.py
+++ b/app.py
@@ -721,12 +721,8 @@ def redraw():
 	try:
 		treeobj = ActivedopTree.from_str(data.get('tree'))
 		msg = treeobj.validate()
-	except Exception as err:
-		if len(str(err)) > 0:
-			error_msg = str(err)
-		else:
-			error_msg = "Your CGEL tree is structurally deficient."
-		msg = "ERROR: " + error_msg + "\n\nPlease correct tree errors before proceeding."
+	except ValueError as err:
+		msg = str(err)
 		treeobj = None
 		has_error = True
 		return jsonify({'html': Markup('%s\n\n%s\n\n%s' % (
@@ -772,13 +768,8 @@ def newlabel():
 	treestr = data.get('tree')
 	try:
 		treeobj, cgel_tree_terminals = graphical_operation_preamble(treestr)
-	except Exception as err:
-		if len(str(err)) > 0:
-			error_msg = str(err)
-		else:
-			error_msg = "Your CGEL tree is structurally deficient."
-		msg = "ERROR: " + error_msg + "\n\nPlease correct tree errors before proceeding."
-		return Markup(msg)
+	except ValueError as err:
+		return Markup(str(err))
 	senttok = treeobj.senttok
 	# FIXME: re-factor; check label AFTER replacing it
 	# now actually replace label at nodeid
@@ -829,13 +820,8 @@ def reattach():
 	treestr = data.get('tree')
 	try:
 		treeobj, cgel_tree_terminals = graphical_operation_preamble(treestr)
-	except Exception as err:
-		if len(str(err)) > 0:
-			error_msg = str(err)
-		else:
-			error_msg = "Your CGEL tree is structurally deficient."
-		msg = "ERROR: " + error_msg + "\n\nPlease correct tree errors before proceeding."
-		return Markup(msg)
+	except ValueError as err:
+		return Markup(str(err))
 	# kludge (can't deep copy treeobj)
 	old_treeobj, _ = graphical_operation_preamble(treestr)
 	try:

--- a/static/script.js
+++ b/static/script.js
@@ -306,8 +306,13 @@ function replacetree() {
 	var el = document.getElementById('tree');
 	xmlhttp.onreadystatechange=function() {
 		if(xmlhttp.readyState==4) { // && xmlhttp.status==200) {
-			el.innerHTML = xmlhttp.responseText;
+			resp = JSON.parse(xmlhttp.responseText)
+			el.innerHTML = resp.html;
 			registerdraggable(el);
+			if (! resp.has_error) {
+				// Update oldtree with the current value from the editor
+				oldtree = editor.getValue();
+			}
 		}
 	};
 	// Create the data object to be sent in a POST request
@@ -329,9 +334,6 @@ function replacetree() {
 
 	// Send the JSON data in the body of the request
 	xmlhttp.send(jsonData);
-
-	// Update oldtree with the current value from the editor
-	oldtree = editor.getValue();
 }
 
 // global to track which node is being modified when label picker is used


### PR DESCRIPTION
If the user makes a text window edit resulting in a deficient tree structure (e.g., a missing double quote around a lemma tag), the user is shown an error. For example: 

<img width="453" alt="Screenshot 2024-11-18 at 12 04 14 PM" src="https://github.com/user-attachments/assets/f75de83a-713c-4815-9b6a-a542f656deaa">

The user is thrown a similar error in cases where a bad text window edit precedes a graphical edit, because it's important that the CGEL tree in the text window is structurally sound before any graphical edit. (Metadata tags, for example, are read off the CGEL tree string and re-added to terminals after a graphical edit). 