### PR TITLE
Compare original tokenization to subsequent modifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -673,6 +673,7 @@ def edit():
 		id = QUEUE[sentno - 1][3]
 		treestr, n = getannotation(username, id) # get tree from database
 		treeobj = ActivedopTree.from_str(treestr)
+		senttok = treeobj.senttok
 	elif 'n' in request.args: # edit the nth automatic parse
 		msg = Markup('<button id="undo" onclick="goback()">Go back</button>')
 		n = int(request.args.get('n', 1))

--- a/app.py
+++ b/app.py
@@ -675,6 +675,8 @@ def edit():
 		treestr, n = getannotation(username, id) # get tree from database
 		treeobj = ActivedopTree.from_str(treestr)
 		senttok = treeobj.senttok
+		# ensures that SENTENCES array is updated with the tokenized sentence
+		SENTENCES[lineno] = ' '.join(senttok)
 	elif 'n' in request.args: # edit the nth automatic parse
 		msg = Markup('<button id="undo" onclick="goback()">Go back</button>')
 		n = int(request.args.get('n', 1))

--- a/app.py
+++ b/app.py
@@ -514,6 +514,13 @@ def retokenize():
 	SENTENCES[lineno] = newtext
 	return jsonify({"success": True})
 
+@app.route('/revert_tokenization', methods=['POST'])
+def revert_tokenization():
+	sentno = int(request.json.get('sentno', 0))
+	lineno = QUEUE[sentno - 1][0]
+	SENTENCES[lineno] = SENTENCES_ORIG[lineno]
+	return jsonify({"success": True, "newtext": SENTENCES_ORIG[lineno]})
+
 @app.route('/annotate/parse')
 @loginrequired
 def parse():

--- a/schema.sql
+++ b/schema.sql
@@ -5,6 +5,8 @@ create table entries (
   username text not null,
   tree text not null,
   cgel_tree text not null,
+  senttok text not null,
+  origtok text not null,
   nbest integer not null,
   constraints integer not null,
   dectree integer not null,

--- a/templates/annotate.html
+++ b/templates/annotate.html
@@ -33,7 +33,7 @@
 		</select>
 		<input type=hidden id=sent value="{{ sent }}" />
 		<input type=hidden id=sentno value="{{ sentno }}" />
-		<input type=submit value="Re-parse" /> <br>
+		<input type=submit value="Re-parse" /> <button id="revertButton" onclick="revertTokenization()">Revert tokenization</button><br>
 		<span id="editableSent" onclick="makeEditable()">{{ sent }}</span>
 		<input type="text" id="editInput" size=120 value="{{sent}}" style="display:none">
 		<button id="cancelButton" onclick="cancelEdit()" style="display:none">Cancel</button>
@@ -56,6 +56,26 @@
 		document.getElementById('editInput').style.display = "none";
 		document.getElementById('cancelButton').style.display = "none";
 		document.getElementById('reTokenizeButton').style.display = "none";
+	}
+
+	function revertTokenization() {
+		var sentno = document.getElementById('sentno').value;
+		fetch('/revert_tokenization', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({sentno: sentno}),
+		})
+		.then(response => response.json())
+		.then(data => {
+			console.log('Success:', data)
+			document.getElementById('editableSent').innerText = data.newtext;
+			document.getElementById('editInput').value = data.newtext;
+		})
+		.catch((error) => {
+			console.error('Error:', error);
+		});
 	}
 	
 	function reTokenize(sentno) {


### PR DESCRIPTION
- Addresses https://github.com/nschneid/activedop/issues/91: once an annotation is accepted, the latest tokenization is displayed to the user when the user subsequently views the sentence. 
- Adds 2 fields to the database: `senttok` and `origtok`. `senttok` is a string which reflects the sentence tokenization after any manual edits; `origtok` is a string reflecting the tokenization prior to any manual edits. 
- Introduces a "Revert tokenization" button in annotate mode. If the user clicks this button, the sentence is re-tokenized according to the original tokenization specified in the input .csv file (the file that `SENTENCES` points to in `settings.cfg`). 