### PR TITLE
Ensure that punct tags in settings count as valid POS

### DIFF
--- a/activedoptree.py
+++ b/activedoptree.py
@@ -425,7 +425,7 @@ class ActivedopTree:
 		return tok.startswith('_.')
 
 	def _isValidPOS(self, x):
-		return x in workerattr('poslabels')
+		return x in workerattr('poslabels') or x in self.app.config['PUNCT_TAGS']
 
 	def _isValidPhraseCat(self, x):
 		return x in workerattr('phrasallabels') or (ALLOW_MULTIWORD_POS and self._isValidPOS(x))


### PR DESCRIPTION
I was getting an error when trying to edit a sentence with punctuation tokens `(` and `)`. The ptree validator (the legacy, pre-CGEL validation procedure -- `_validate_ptree()` in `activedoptree.py`) wasn't recognizing them as valid POS tags. This change ensures that any punctuation tags specified in `PUNCT_TAGS` (in settings.cfg) count as valid POS for the ptree validator. 