### PR TITLE
Speedup `ActivedopTree` functions with custom deep copying

### DIFF
--- a/activedoptree.py
+++ b/activedoptree.py
@@ -175,7 +175,7 @@ class ActivedopTree:
 		"""
 		# guardrails against producing illict tree structures
 		tree, senttok = self.ptree, self.senttok
-		tree_copy = tree.copy(deep=True)
+		tree_copy = ParentedTree.parse(str(tree), label_pattern = r'[^\s]+')
 		for subt in tree_copy.subtrees(lambda t: t.height() == 2):
 			i = subt[0]
 			# if initial parse labels non-gaps as GAP, change to N-Head by default
@@ -199,7 +199,7 @@ class ActivedopTree:
 		Convert it to a CGELTree object, with prepunct and postpunct attributes assigned to the terminal nodes.
 		Assumes that tree has been processed by apply_standard_labels().
 		"""
-		tree_copy = ParentedTree.parse(str(self.ptree))
+		tree_copy = ParentedTree.parse(str(self.ptree), label_pattern = r'[^\s]+')
 		senttok = self.senttok
 		# create three lists of equal lengths: one list non-punctuation token strings, one list of lists prepending punctuation, and one list of lists for appending punctuation
 		non_punct_tokens = []
@@ -290,7 +290,7 @@ class ActivedopTree:
 						terminal_count += 1
 
 		# Create a copy of the tree to avoid modifying the original
-		tree_copy = ParentedTree.parse(str(tree))
+		tree_copy = ParentedTree.parse(str(tree), label_pattern = r'[^\s]+')
 		_number_terminals(tree_copy)
 		return tree_copy
 
@@ -321,7 +321,7 @@ class ActivedopTree:
 					del tree[i]
 
 		# Create a copy of the tree to avoid modifying the original
-		tree_copy = tree.copy(deep=True)
+		tree_copy = ParentedTree.parse(str(tree), label_pattern = r'[^\s]+')
 		_remove_punct(tree_copy)
 		return self._number_terminals(self._prune_empty_non_terminals(tree_copy))
 	
@@ -362,7 +362,7 @@ class ActivedopTree:
 		coindexed = defaultdict(set)	# {coindexationvar -> {labels}}
 		for node in tree.subtrees():
 			# create copy of node to validate POS and function tags
-			node_to_validate = ParentedTree.parse(str(node))
+			node_to_validate = ParentedTree.parse(str(node), label_pattern = r'[^\s]+')
 			# strip -p from label if present
 			if node_to_validate.label.endswith('-p'):
 				node_to_validate.label = node_to_validate.label[:-2]

--- a/activedoptree.py
+++ b/activedoptree.py
@@ -199,7 +199,7 @@ class ActivedopTree:
 		Convert it to a CGELTree object, with prepunct and postpunct attributes assigned to the terminal nodes.
 		Assumes that tree has been processed by apply_standard_labels().
 		"""
-		tree_copy = self.ptree.copy(deep=True)
+		tree_copy = ParentedTree.parse(str(self.ptree))
 		senttok = self.senttok
 		# create three lists of equal lengths: one list non-punctuation token strings, one list of lists prepending punctuation, and one list of lists for appending punctuation
 		non_punct_tokens = []
@@ -290,7 +290,7 @@ class ActivedopTree:
 						terminal_count += 1
 
 		# Create a copy of the tree to avoid modifying the original
-		tree_copy = tree.copy(deep=True)
+		tree_copy = ParentedTree.parse(str(tree))
 		_number_terminals(tree_copy)
 		return tree_copy
 
@@ -362,7 +362,7 @@ class ActivedopTree:
 		coindexed = defaultdict(set)	# {coindexationvar -> {labels}}
 		for node in tree.subtrees():
 			# create copy of node to validate POS and function tags
-			node_to_validate = copy.deepcopy(node)
+			node_to_validate = ParentedTree.parse(str(node))
 			# strip -p from label if present
 			if node_to_validate.label.endswith('-p'):
 				node_to_validate.label = node_to_validate.label[:-2]


### PR DESCRIPTION
This seems to come in handy especially when dealing with big trees.

I used `cProfile` to measure time to 1) initialize an `ActivedopTree` object from a large string, and 2) call the `validate()` method on that object. An excerpt of the profiler stats before optimization: 

```
     2705535 function calls (2240490 primitive calls) in 1.033 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.842    0.842 /Users/bw/Documents/GitHub/activedop/activedoptree.py:117(validate)
        1    0.005    0.005    0.834    0.834 /Users/bw/Documents/GitHub/activedop/activedoptree.py:354(_validate_ptree)
293526/138    0.346    0.000    0.822    0.006 /usr/local/Cellar/python@3.9/3.9.19_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/copy.py:128(deepcopy)
19044/138    0.075    0.000    0.821    0.006 /usr/local/Cellar/python@3.9/3.9.19_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/copy.py:258(_reconstruct)
19044/138    0.030    0.000    0.819    0.006 /usr/local/Cellar/python@3.9/3.9.19_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/copy.py:209(_deepcopy_tuple)
19044/138    0.014    0.000    0.819    0.006 /usr/local/Cellar/python@3.9/3.9.19_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/copy.py:210(<listcomp>)
19044/138    0.066    0.000    0.818    0.006 /usr/local/Cellar/python@3.9/3.9.19_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/copy.py:226(_deepcopy_dict)
19044/1523    0.027    0.000    0.761    0.000 /usr/local/Cellar/python@3.9/3.9.19_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/copy.py:200(_deepcopy_list)
        1    0.000    0.000    0.126    0.126 /Users/bw/Documents/GitHub/activedop/activedoptree.py:131(gtree)
        2    0.000    0.000    0.105    0.053 /Users/bw/Documents/GitHub/activedop/.venv/lib/python3.9/site-packages/disco_dop-0.6a0-py3.9-macosx-13-x86_64.egg/discodop/tree.py:1044(__init__)
        2    0.004    0.002    0.104    0.052 /Users/bw/Documents/GitHub/activedop/.venv/lib/python3.9/site-packages/disco_dop-0.6a0-py3.9-macosx-13-x86_64.egg/discodop/tree.py:1095(nodecoords)
```

After optimization:

```
571026 function calls (491097 primitive calls) in 0.232 seconds
```