### PR TITLE
remote app support 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,5 @@ ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0
 ENV FLASK_ENV=production
 
-# Initialize the database
-# RUN python -m flask initdb 
-
-# Initialize priorities
-#RUN python -m flask initpriorities
-
 # Run the Flask application with threading enabled
 CMD ["python", "-m", "flask", "run", "--with-threads"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY worker.py worker.py
 COPY workerattr.py workerattr.py
 
 COPY newsentsExample.csv newsentsExample.csv
+COPY newsentsExample.csv.rankings.json newsentsExample.csv.rankings.json
 
 # Install dependencies
 
@@ -38,12 +39,13 @@ RUN pip3 install -r requirements.txt
 
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0
+ENV FLASK_ENV=production
 
 # Initialize the database
-RUN python -m flask initdb
+# RUN python -m flask initdb 
 
 # Initialize priorities
-RUN python -m flask initpriorities
+#RUN python -m flask initpriorities
 
 # Run the Flask application with threading enabled
 CMD ["python", "-m", "flask", "run", "--with-threads"]

--- a/app.py
+++ b/app.py
@@ -33,6 +33,7 @@ import sys
 import csv
 import json
 import sqlite3
+import psycopg2
 import logging
 import subprocess
 import click
@@ -111,15 +112,23 @@ logger.setLevel(logging.DEBUG)
 logger.handlers[0].setFormatter(logging.Formatter(
 		fmt='%(asctime)s %(message)s', datefmt='%Y-%m-%d %H:%M:%S'))
 
+if app.config['DATABASE'] == 'remote':
+	db_blank = '%s'
+else:	
+	db_blank = '?'
+
 def refreshqueue(username):
 	""""Ensures that user can view annotations of sentences not in the 'initpriorities' queue.
 	These sentences are shown first, before the prioritized queue."""
 	db = getdb()
-	cur = db.execute(
-		'SELECT id, sentno, cgel_tree FROM entries WHERE username = ? ORDER BY sentno ASC',
-		(username, )
-	)
-	dbentries = cur.fetchall()
+	cmd = 'SELECT id, sentno, cgel_tree FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(db_blank)
+	if app.config['DATABASE'] == 'remote':
+		with db.cursor() as cur:
+			cur.execute(cmd, (username,))
+			dbentries = cur.fetchall()
+	else:
+		cur = db.execute(cmd, (username,))
+		dbentries = cur.fetchall()
 	queue_ids = [entry[3] for entry in QUEUE]
 	for row in dbentries:
 		id = row[0]
@@ -140,11 +149,14 @@ def initpriorities(username):
 	Sentences with saved annotations are included first in the order and are not re-parsed."""
 	sentfilename = app.config['SENTENCES']
 	db = getdb()
-	cur = db.execute(
-		'SELECT * FROM entries WHERE username = ? ORDER BY sentno ASC',
-		(username, )
-	)
-	dbentries = cur.fetchall()
+	cmd = 'SELECT id FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(db_blank)
+	if app.config['DATABASE'] == 'remote':
+		with db.cursor() as cur:
+			cur.execute(cmd, (username,))
+			dbentries = cur.fetchall()
+	else:
+		cur = db.execute(cmd, (username,))
+		dbentries = cur.fetchall()
 	dbentryids = {a[0] for a in dbentries}
 	if sentfilename is None:
 		raise ValueError('SENTENCES not configured')
@@ -227,41 +239,60 @@ def initdb():
 	"""Initializes the database."""
 	db = getdb()
 	with app.open_resource('schema.sql', mode='r') as inp:
-		db.cursor().executescript(inp.read())
+		schema = inp.read()
+	if app.config['DATABASE'] == 'remote':
+		with db.cursor() as cur:
+			for statement in schema.split(';'):
+				if statement.strip():
+					cur.execute(statement)
+	else:
+		db.cursor().executescript(schema)
 	db.commit()
 	app.logger.info('Initialized the database.')
 
 
 def connectdb():
 	"""Connects to the specific database."""
-	result = sqlite3.connect(app.config['DATABASE'])
-	# result.row_factory = sqlite3.Row
+	if app.config['DATABASE'] == 'remote':
+		db_params = {
+            "host": os.getenv("DB_HOST"),  
+            "database": os.getenv("DB_NAME"),
+            "user": os.getenv("DB_UNAME"),       # default is often 'postgres'
+            "password": os.getenv("DB_PWD"),
+            "port": os.getenv("DB_PORT")                 # default PostgreSQL port
+        }
+		result = psycopg2.connect(**db_params)
+	else:
+		result = sqlite3.connect(app.config['DATABASE'])
 	return result
 
 
 def getdb():
 	"""Opens a new database connection if there is none yet for the
 	current application context."""
-	if not hasattr(g, 'sqlitedb'):
-		g.sqlitedb = connectdb()
-	return g.sqlitedb
+	if not hasattr(g, 'db'):
+		g.db = connectdb()
+	return g.db
 
 
 @app.teardown_appcontext
 def closedb(error):
 	"""Closes the database again at the end of the request."""
-	if hasattr(g, 'sqlitedb'):
-		g.sqlitedb.close()
+	if hasattr(g, 'db'):
+		g.db.close()
 
 @app.route('/annotate/get_data_psv')
 def get_data_psv():
 	username = session['username']
 	db = getdb()
-	cur = db.execute(
-		'SELECT * FROM entries WHERE username = ? ORDER BY sentno ASC',
-		(username, )
-	)
-	rows = cur.fetchall()
+	cmd = 'SELECT * FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(db_blank)
+	if app.config['DATABASE'] == 'remote':
+		with db.cursor() as cur:
+			cur.execute(cmd, (username,))
+			rows = cur.fetchall()
+	else:
+		cur = db.execute(cmd, (username,))
+		rows = cur.fetchall()
 	output_dir = "tmp"
 	if not os.path.exists(output_dir):
 		os.makedirs(output_dir)
@@ -281,11 +312,14 @@ def firstunannotated(username):
 	"""Return index of first unannotated sentence,
 	according to the prioritized order."""
 	db = getdb()
-	cur = db.execute(
-			'select id from entries where username = ? '
-			'order by sentno asc',
-			(username, ))
-	entries = {a[0] for a in cur}
+	cmd = 'SELECT id FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(db_blank)
+	if app.config['DATABASE'] == 'remote':
+		with db.cursor() as cur:
+			cur.execute(cmd, (username,))
+			entries = {a[0] for a in cur}
+	else:
+		cur = db.execute(cmd, (username,))
+		entries = {a[0] for a in cur}
 	# sentno=prioritized index, lineno=original index
 	for sentno, (_, _, _, id) in enumerate(QUEUE, 1):
 		if id not in entries:
@@ -296,28 +330,29 @@ def firstunannotated(username):
 def numannotated(username):
 	"""Number of unannotated sentences for an annotator."""
 	db = getdb()
-	cur = db.execute('select count(sentno) from entries where username = ?',
-			(username, ))
-	result = cur.fetchone()
+	cmd = 'SELECT count(sentno) FROM entries WHERE username = {0}'.format(db_blank)
+	if app.config['DATABASE'] == 'remote':
+		with db.cursor() as cur:
+			cur.execute(cmd, (username,))
+			result = cur.fetchone()
+	else:
+		cur = db.execute(cmd, (username,))
+		result = cur.fetchone()
 	return result[0]
 
 
 def getannotation(username, id):
 	"""Fetch annotation of a single sentence from database."""
 	db = getdb()
-	if app.config['CGELVALIDATE'] is None:
-		cur = db.execute(
-				'select tree, nbest '
-				'from entries '
-				'where username = ? and id = ? ',
-				(username, id))
+	selection = 'cgel_tree, nbest' if app.config['CGELVALIDATE'] else 'tree, nbest'
+	cmd = 'select {0} from entries where username = {1} and id = {1}'.format(selection, db_blank)
+	if app.config['DATABASE'] == 'remote':
+		with db.cursor() as cur:
+			cur.execute(cmd, (username, id))
+			entry = cur.fetchone()
 	else:
-		cur = db.execute(
-				'select cgel_tree, nbest '
-				'from entries '
-				'where username = ? and id = ? ',
-				(username, id))
-	entry = cur.fetchone()
+		cur = db.execute(cmd, (username, id))
+		entry = cur.fetchone()
 	return (None, 0) if entry is None else (entry[0], entry[1])
 
 
@@ -325,22 +360,35 @@ def readannotations(username=None):
 	"""Get all annotations, or ones by a given annotator."""
 	db = getdb()
 	if username is None:
-		cur = db.execute(
-				'select sentno, tree from entries '
-				'order by sentno asc')
+		cmd = 'select sentno, tree from entries order by sentno asc'
+		if app.config['DATABASE'] == 'remote':
+			with db.cursor() as cur:
+				cur.execute(cmd)
+				entries = cur.fetchall()
+		else:
+			cur = db.execute(cmd)
+			entries = cur.fetchall()
 	else:
-		cur = db.execute(
-				'select sentno, tree from entries where username = ? '
-				'order by sentno asc',
-				(username, ))
-	entries = cur.fetchall()
+		cmd = 'select sentno, tree from entries where username = {0} order by sentno asc'.format(db_blank)
+		if app.config['DATABASE'] == 'remote':
+			with db.cursor() as cur:
+				cur.execute(cmd, (username,))
+				entries = cur.fetchall()
+		else:
+			cur = db.execute(cmd, (username,))
+			entries = cur.fetchall()
 	return OrderedDict(entries)
 
 
 def addentry(id, sentno, tree, cgel_tree, actions):
 	"""Add an annotation to the database."""
 	db = getdb()
-	db.execute(
+	if app.config['DATABASE'] == 'remote':
+		query = 'INSERT INTO entries VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)'
+		with db.cursor() as cur:
+			cur.execute(query, (id, sentno, session['username'], tree, cgel_tree, *actions, datetime.now().strftime('%F %H:%M:%S')))
+	else:
+		db.execute(
 			'insert or replace into entries '
 			'values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
 			(id, sentno, session['username'], tree, cgel_tree, *actions,
@@ -388,10 +436,14 @@ def get_id():
 	id = None
 	# verify that the ID is unique 
 	db = getdb()
-	cur = db.execute(
-		'SELECT id FROM entries ORDER BY sentno ASC'
-	)
-	entries = cur.fetchall()
+	cmd = 'SELECT id FROM entries ORDER BY sentno ASC'
+	if app.config['DATABASE'] == 'remote':
+		with db.cursor() as cur:
+			cur.execute(cmd)
+			entries = cur.fetchall()
+	else:
+		cur = db.execute(cmd)
+		entries = cur.fetchall()
 	existing_ids = {entry[0] for entry in entries} | {entry[3] for entry in QUEUE}
 	while id is None or id in existing_ids:
 		id = ''.join(random.choices(string.ascii_uppercase + string.digits, k=6))
@@ -408,10 +460,14 @@ def direct_entry():
 	elif not sentid:
 		return jsonify({'error': 'Sentence ID is empty.'})
 	db = getdb()
-	cur = db.execute(
-		'SELECT id FROM entries ORDER BY sentno ASC'
-	)
-	entries = cur.fetchall()
+	cmd = 'SELECT id FROM entries ORDER BY sentno ASC'
+	if app.config['DATABASE'] == 'remote':
+		with db.cursor() as cur:
+			cur.execute(cmd)
+			entries = cur.fetchall()
+	else:
+		cur = db.execute(cmd)
+		entries = cur.fetchall()
 	existing_ids = {entry[0] for entry in entries} | {entry[3] for entry in QUEUE}
 	if sentid in existing_ids:
 		return jsonify({'error': 'Sentence ID already exists in the database or queue.'})
@@ -567,9 +623,12 @@ def undoaccept():
 	sentid = request.json.get('sentid', 0)
 	username = session['username']
 	db = getdb()
-	db.execute(
-	'DELETE FROM entries WHERE username = ? AND id = ?',
-	(username, sentid))
+	cmd = 'DELETE FROM entries WHERE username = {0} AND id = {0}'.format(db_blank)
+	if app.config['DATABASE'] == 'remote':
+		with db.cursor() as cur:
+			cur.execute(cmd, (username, sentid))
+	else:
+		db.execute(cmd, (username, sentid))
 	db.commit()
 	return jsonify({"success": True})
 

--- a/app.py
+++ b/app.py
@@ -120,7 +120,7 @@ else:
 def refreshqueue(username):
 	""""Ensures that user can view annotations of sentences not in the 'initpriorities' queue.
 	These sentences are shown first, before the prioritized queue."""
-	cmd = 'SELECT id, sentno, cgel_tree FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(DB_BLANK)
+	cmd = f'SELECT id, sentno, cgel_tree FROM entries WHERE username = {DB_BLANK} ORDER BY sentno ASC'
 	db = getdb()
 	cur = db.cursor()
 	cur.execute(cmd, (username,))
@@ -145,7 +145,7 @@ def initpriorities(username):
 	Sentences with saved annotations are included first in the order and are not re-parsed."""
 	sentfilename = app.config['SENTENCES']
 	db = getdb()
-	cmd = 'SELECT id FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(DB_BLANK)
+	cmd = f'SELECT id FROM entries WHERE username = {DB_BLANK} ORDER BY sentno ASC'
 	cur = db.cursor()
 	cur.execute(cmd, (username,))
 	dbentries = cur.fetchall()
@@ -276,7 +276,7 @@ def closedb(error):
 @app.route('/annotate/get_data_psv')
 def get_data_psv():
 	username = session['username']
-	cmd = 'SELECT * FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(DB_BLANK)
+	cmd = f'SELECT * FROM entries WHERE username = {DB_BLANK} ORDER BY sentno ASC'
 	db = getdb()
 	cur = db.cursor()
 	cur.execute(cmd, (username,))
@@ -300,7 +300,7 @@ def firstunannotated(username):
 	"""Return index of first unannotated sentence,
 	according to the prioritized order."""
 	db = getdb()
-	cmd = 'SELECT id FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(DB_BLANK)
+	cmd = f'SELECT id FROM entries WHERE username = {DB_BLANK} ORDER BY sentno ASC'
 	cur = db.cursor() 
 	cur.execute(cmd, (username,))
 	entries = {a[0] for a in cur}
@@ -314,7 +314,7 @@ def firstunannotated(username):
 def numannotated(username):
 	"""Number of unannotated sentences for an annotator."""
 	db = getdb()
-	cmd = 'SELECT count(sentno) FROM entries WHERE username = {0}'.format(DB_BLANK)
+	cmd = f'SELECT count(sentno) FROM entries WHERE username = {DB_BLANK}'
 	cur = db.cursor()
 	cur.execute(cmd, (username,))
 	result = cur.fetchone()
@@ -325,7 +325,7 @@ def getannotation(username, id):
 	"""Fetch annotation of a single sentence from database."""
 	db = getdb()
 	selection = 'cgel_tree, nbest' if app.config['CGELVALIDATE'] else 'tree, nbest'
-	cmd = 'select {0} from entries where username = {1} and id = {1}'.format(selection, DB_BLANK)
+	cmd = f'select {selection} from entries where username = {DB_BLANK} and id = {DB_BLANK}'
 	cur = db.cursor()
 	cur.execute(cmd, (username, id))
 	entry = cur.fetchone()
@@ -340,7 +340,7 @@ def readannotations(username=None):
 		cmd = 'select sentno, tree from entries order by sentno asc'
 		cur.execute(cmd)
 	else:
-		cmd = 'select sentno, tree from entries where username = {0} order by sentno asc'.format(DB_BLANK)
+		cmd = f'select sentno, tree from entries where username = {DB_BLANK} order by sentno asc'
 		cur.execute(cmd, (username,))
 	entries = cur.fetchall()
 	return OrderedDict(entries)
@@ -582,7 +582,7 @@ def annotate(sentno):
 def undoaccept():
 	sentid = request.json.get('sentid', 0)
 	username = session['username']
-	cmd = 'DELETE FROM entries WHERE username = {0} AND id = {0}'.format(DB_BLANK)
+	cmd = f'DELETE FROM entries WHERE username = {DB_BLANK} AND id = {DB_BLANK}'
 	db = getdb()
 	cur = db.cursor()
 	cur.execute(cmd, (username, sentid))

--- a/app.py
+++ b/app.py
@@ -113,14 +113,14 @@ logger.handlers[0].setFormatter(logging.Formatter(
 		fmt='%(asctime)s %(message)s', datefmt='%Y-%m-%d %H:%M:%S'))
 
 if app.config['DATABASE'] == 'remote':
-	db_blank = '%s'
+	DB_BLANK = '%s'
 else:	
-	db_blank = '?'
+	DB_BLANK = '?'
 
 def refreshqueue(username):
 	""""Ensures that user can view annotations of sentences not in the 'initpriorities' queue.
 	These sentences are shown first, before the prioritized queue."""
-	cmd = 'SELECT id, sentno, cgel_tree FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(db_blank)
+	cmd = 'SELECT id, sentno, cgel_tree FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(DB_BLANK)
 	db = getdb()
 	cur = db.cursor()
 	cur.execute(cmd, (username,))
@@ -145,7 +145,7 @@ def initpriorities(username):
 	Sentences with saved annotations are included first in the order and are not re-parsed."""
 	sentfilename = app.config['SENTENCES']
 	db = getdb()
-	cmd = 'SELECT id FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(db_blank)
+	cmd = 'SELECT id FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(DB_BLANK)
 	cur = db.cursor()
 	cur.execute(cmd, (username,))
 	dbentries = cur.fetchall()
@@ -276,7 +276,7 @@ def closedb(error):
 @app.route('/annotate/get_data_psv')
 def get_data_psv():
 	username = session['username']
-	cmd = 'SELECT * FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(db_blank)
+	cmd = 'SELECT * FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(DB_BLANK)
 	db = getdb()
 	cur = db.cursor()
 	cur.execute(cmd, (username,))
@@ -300,7 +300,7 @@ def firstunannotated(username):
 	"""Return index of first unannotated sentence,
 	according to the prioritized order."""
 	db = getdb()
-	cmd = 'SELECT id FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(db_blank)
+	cmd = 'SELECT id FROM entries WHERE username = {0} ORDER BY sentno ASC'.format(DB_BLANK)
 	cur = db.cursor() 
 	cur.execute(cmd, (username,))
 	entries = {a[0] for a in cur}
@@ -314,7 +314,7 @@ def firstunannotated(username):
 def numannotated(username):
 	"""Number of unannotated sentences for an annotator."""
 	db = getdb()
-	cmd = 'SELECT count(sentno) FROM entries WHERE username = {0}'.format(db_blank)
+	cmd = 'SELECT count(sentno) FROM entries WHERE username = {0}'.format(DB_BLANK)
 	cur = db.cursor()
 	cur.execute(cmd, (username,))
 	result = cur.fetchone()
@@ -325,7 +325,7 @@ def getannotation(username, id):
 	"""Fetch annotation of a single sentence from database."""
 	db = getdb()
 	selection = 'cgel_tree, nbest' if app.config['CGELVALIDATE'] else 'tree, nbest'
-	cmd = 'select {0} from entries where username = {1} and id = {1}'.format(selection, db_blank)
+	cmd = 'select {0} from entries where username = {1} and id = {1}'.format(selection, DB_BLANK)
 	cur = db.cursor()
 	cur.execute(cmd, (username, id))
 	entry = cur.fetchone()
@@ -340,7 +340,7 @@ def readannotations(username=None):
 		cmd = 'select sentno, tree from entries order by sentno asc'
 		cur.execute(cmd)
 	else:
-		cmd = 'select sentno, tree from entries where username = {0} order by sentno asc'.format(db_blank)
+		cmd = 'select sentno, tree from entries where username = {0} order by sentno asc'.format(DB_BLANK)
 		cur.execute(cmd, (username,))
 	entries = cur.fetchall()
 	return OrderedDict(entries)
@@ -582,7 +582,7 @@ def annotate(sentno):
 def undoaccept():
 	sentid = request.json.get('sentid', 0)
 	username = session['username']
-	cmd = 'DELETE FROM entries WHERE username = {0} AND id = {0}'.format(db_blank)
+	cmd = 'DELETE FROM entries WHERE username = {0} AND id = {0}'.format(DB_BLANK)
 	db = getdb()
 	cur = db.cursor()
 	cur.execute(cmd, (username, sentid))

--- a/cgelbank2-punct/params.prm
+++ b/cgelbank2-punct/params.prm
@@ -1,7 +1,7 @@
 top='ROOT',
 stages=[
   dict(
-    name='dop', mode='plcfrs', dop='doubledop',
+    name='dop', mode='pcfg', dop='doubledop',
 	m=1000, estimator='rfe', objective = 'mpp'
   ),
 ],

--- a/cgelbank2-punct/params.prm
+++ b/cgelbank2-punct/params.prm
@@ -3,6 +3,7 @@ stages=[
   dict(
     name='dop', mode='plcfrs', dop='doubledop',
 	m=1000, estimator='rfe', objective = 'mpp',
+	beam_beta = 0.01
   ),
 ],
 

--- a/cgelbank2-punct/params.prm
+++ b/cgelbank2-punct/params.prm
@@ -2,8 +2,7 @@ top='ROOT',
 stages=[
   dict(
     name='dop', mode='plcfrs', dop='doubledop',
-	m=1000, estimator='rfe', objective = 'mpp',
-	beam_beta = 0.01
+	m=1000, estimator='rfe', objective = 'mpp'
   ),
 ],
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 scikit-learn
 pylatexenc
 Werkzeug==2.2.2
+psycopg2-binary

--- a/settings.cfg
+++ b/settings.cfg
@@ -3,6 +3,7 @@ DEBUG = False
 GRAMMAR = 'cgelbank2-punct/'
 SENTENCES = 'newsentsExample.csv'
 LIMIT = 200
+DATABASE = 'remote'
 ANNOTATIONHELP = None
 ACCOUNTS = {
 	'JoeAnnotator': 'example',


### PR DESCRIPTION
Merge in after https://github.com/nschneid/activedop/pull/129

- Creates support for remote PostgreSQL databases -- desirable in situations where the app needs to be served separately from the db. (Note that AWS Lightsail doesn't have prebuilt sqlite database instances, hence the change to PostgreSQL, one of two supported database types on Lightsail). Remote database connection params are passed as environment variables. 
- Changes the default parser from `plcrfs` to `pcfg` for faster parsing at inference time. (Would need to be switched back to `plcrfs` for train). 
- Passes a pre-computed `rankings.json` file to the Docker app. (No need to run initpriorities). 
- If using a remote database: assumes that the database has been setup with a call to `initdb`, e.g., 

```
DB_HOST="XXX.amazonaws.com" DB_NAME="postgres" DB_UNAME="XXX" DB_PWD="XXX" DB_PORT="XXX" FLASK_APP=app.py flask initdb
```