### PR TITLE
optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,38 @@
-FROM python:3.12.3
+FROM python:3.11
 EXPOSE 5000/tcp
 WORKDIR /app
 
-# Copy resources
+# Install dependencies and submodules
 
+COPY requirements.txt requirements.txt
 COPY roaringbitmap roaringbitmap/
+COPY disco-dop/ disco-dop/
+
+RUN pip3 install setuptools
+RUN pip3 install cython==3.0.12
+
+# OPTIONAL: Install LaTeX for PDF generation (if not using an external service)
+# RUN apt-get update && apt-get install -y make texlive-latex-extra
+
+WORKDIR roaringbitmap/
+RUN python setup.py install
+WORKDIR ../disco-dop/
+RUN pip3 install -r requirements.txt
+RUN env CC=gcc python setup.py install
+WORKDIR ..
+
+RUN pip3 install -r requirements.txt
+
+# Copy the rest of the resources
+
 COPY templates/ templates/
 COPY cgel/ cgel/
 COPY cgelbank2-punct/ cgelbank2-punct/
-COPY disco-dop/ disco-dop/
 COPY static/ static/
 
-COPY requirements.txt requirements.txt
 COPY settings.cfg settings.cfg
+
+# Assumes a local SQLite database named annotate.db exists
 COPY annotate.db annotate.db
 
 COPY app.py app.py
@@ -23,19 +43,6 @@ COPY workerattr.py workerattr.py
 
 COPY newsentsExample.csv newsentsExample.csv
 COPY newsentsExample.csv.rankings.json newsentsExample.csv.rankings.json
-
-# Install dependencies
-
-RUN apt-get update && apt-get install -y make texlive-latex-extra && \
-	pip3 install cython && \
-	pip3 install setuptools
-WORKDIR roaringbitmap/
-RUN python setup.py install
-WORKDIR ../disco-dop/
-RUN pip3 install -r requirements.txt
-RUN env CC=gcc python setup.py install
-WORKDIR ..
-RUN pip3 install -r requirements.txt
 
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0

--- a/settings.cfg
+++ b/settings.cfg
@@ -3,7 +3,7 @@ DEBUG = False
 GRAMMAR = 'cgelbank2-punct/'
 SENTENCES = 'newsentsExample.csv'
 LIMIT = 200
-DATABASE = 'remote'
+DATABASE = 'annotate.db'
 ANNOTATIONHELP = None
 ACCOUNTS = {
 	'JoeAnnotator': 'example',


### PR DESCRIPTION
- Changes python environment to 3.11 (because 3.12+ is not supported, https://github.com/nschneid/activedop/issues/120)
- Specifies a cython version to prevent errors in roaringbitmap install (https://github.com/nschneid/activedop/issues/138)
- Enables more efficient Docker build caching: install dependencies first, then copy over application scripts and data. 
- `texlive` installation step is commented out by default; it's a bulky dependency, and we're moving towards the option of using an externally-hosted tex-to-pdf conversion service (https://github.com/nschneid/activedop/pull/140)